### PR TITLE
Fix edited name in story content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # BotFlow API
-This repository is intended to obtain data pertaining to content created or edited within the BotFlow platform.
+This repository is an API of the BotFlow platform [https://github.com/lappis-unb/BotFlow](https://github.com/lappis-unb/BotFlow)
 
 ## How to Contribute
 To contribute to our API just follow the steps below!
 
--First we will enable a local environment for work, so just follow the step by step described below:
+- First we will enable a local environment for work, so just follow the step by step described below:
     
 * Check Prerequisites:
 
@@ -57,7 +57,7 @@ Stable version of the API [Access here](https://botflow.api.lappis.rocks/api-doc
 
 ## Generate jwtRS256 Key
 
-To run this project is necessary to create a jwtRS256 key in the private foder. To create the key run the following commands on the `server/private/` folder:
+To run this project is necessary to create a jwtRS256 key in the private folder. To create the key run the following commands on the `server/private/` folder:
 
 ``` sh
 ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key

--- a/src/api/models/story.py
+++ b/src/api/models/story.py
@@ -34,6 +34,7 @@ class StorySerializer(serializers.ModelSerializer):
         for i, element in enumerate(obj.content):
             element_obj = elements[element['type']].filter(pk=element['id']).first()
             obj.content[i]['example'] = random.choice(getattr(element_obj, field[element['type']]))
+            obj.content[i]['name'] = getattr(element_obj, 'name')
 
     def get_content(self, obj):
         self.get_example(obj)

--- a/src/api/models/story.py
+++ b/src/api/models/story.py
@@ -48,6 +48,8 @@ class StoryListSerializer(serializers.ModelSerializer):
     content = serializers.SerializerMethodField()
 
     def get_content(self, obj):
+        StorySerializer.get_example(self, obj)
+
         return [{
             'name': content['name'],
             'type': content['type']


### PR DESCRIPTION
Previously, when an utter or intent got it's name updated, it wasn't taking effect in story content field. Now, the field is being reconstructed on every request to always show the updated name