### PR TITLE
FIX Changing Dockerfile to fix django import

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,7 @@
-FROM debian:buster-slim
+FROM python:3
+ENV PYTHONUNBUFFERED=1
 
 EXPOSE 8000
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 \
-        python3-pip \
-        python3-crypto \
-        python3-pyodbc \
-        python3-setuptools
-
-RUN pip3 install --no-cache-dir toolz
 
 RUN mkdir src
 
@@ -20,4 +12,3 @@ COPY requirements.txt requirements.txt
 COPY runserver.sh runserver.sh
 
 RUN pip3 install -r requirements.txt
-


### PR DESCRIPTION
To fix the bug described in issue [#169](https://github.com/lappis-unb/BotFlow/issues/169), the Dockerfile was changed.

![Screenshot_20210323_162333](https://user-images.githubusercontent.com/22080321/112206212-6d7b2480-8bf4-11eb-9d8b-67ec2478ae2a.png)

The changes applied were made in the following lines:
- Line 1 was changed to create the parenting image from python 3;
- Line 2 was added to create an env;
- The following code was deleted because it creates steps that were not necessary.

```
RUN apt-get update && apt-get install -y --no-install-recommends \
        python3 \
        python3-pip \
        python3-crypto \
        python3-pyodbc \
        python3-setuptools

RUN pip3 install --no-cache-dir toolz
```

The remaining code was left without changes from the original Dockerfile.